### PR TITLE
Build and publish with github actions

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -57,8 +57,7 @@ jobs:
             docker build . --file Dockerfile
           fi
 
-  # Push image to GitHub Packages.
-  # See also https://docs.docker.com/docker-hub/builds/
+  # Pushes a docker image to github packages, then creates a git tag called 'latest'.
   push:
     # Ensure test job passes before pushing image.
     needs: test
@@ -78,7 +77,6 @@ jobs:
         run: docker build --tag $IMAGE_NAME .
 
       - name: Log into GitHub Container Registry
-      # TODO: Create a PAT with `read:packages` and `write:packages` scopes and save it as an Actions secret `CR_PAT`
         run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Push image to GitHub Container Registry

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -1,16 +1,28 @@
-name: .NET Core
+name: Build and publish
 
 on:
   push:
-    branches: [ master ]
+    # Publish `master` as Docker `latest` image.
+    branches:
+      - master
+
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+
+  # Run tests for any PRs.
   pull_request:
-    branches: [ master ]
+
+env:
+  # TODO: Change variable to your image's name.
+  IMAGE_NAME: sweatometer
 
 defaults:
   run:
     working-directory: Sweatometer
 
 jobs:
+
   build:
 
     runs-on: ubuntu-latest
@@ -27,3 +39,61 @@ jobs:
       run: dotnet build --configuration Release --no-restore
     - name: Test
       run: dotnet test --no-restore --verbosity normal
+
+  # Run tests.
+  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run tests
+        run: |
+          if [ -f docker-compose.test.yml ]; then
+            docker-compose --file docker-compose.test.yml build
+            docker-compose --file docker-compose.test.yml run sut
+          else
+            docker build . --file Dockerfile
+          fi
+
+  # Push image to GitHub Packages.
+  # See also https://docs.docker.com/docker-hub/builds/
+  push:
+    # Ensure test job passes before pushing image.
+    needs: test
+
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker build --tag $IMAGE_NAME .
+
+      - name: Log into GitHub Container Registry
+      # TODO: Create a PAT with `read:packages` and `write:packages` scopes and save it as an Actions secret `CR_PAT`
+        run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push image to GitHub Container Registry
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -67,6 +67,11 @@ jobs:
     if: github.event_name == 'push'
 
     steps:
+      - uses: actions/checkout@master
+        with:
+          # Fetches entire history, so we can analyze commits since last tag
+          fetch-depth: 0
+
       - uses: actions/checkout@v2
 
       - name: Build image
@@ -97,3 +102,9 @@ jobs:
 
           docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
           docker push $IMAGE_ID:$VERSION
+
+      - name: Bump version and push tag
+        uses: anothrNick/github-tag-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CUSTOM_TAG: latest

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -103,7 +103,13 @@ jobs:
           docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
           docker push $IMAGE_ID:$VERSION
 
-      - name: Bump version and push tag
+      - name: Remove latest tag
+        uses: dev-drprasad/delete-tag-and-release@v0.1.2
+        with:
+          tag_name: latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update latest tag
         uses: anothrNick/github-tag-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -1,0 +1,29 @@
+name: .NET Core
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+defaults:
+  run:
+    working-directory: Sweatometer
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.301
+    - name: Install dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --configuration Release --no-restore
+    - name: Test
+      run: dotnet test --no-restore --verbosity normal

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ dotnet run
 ```bash
 cd Sweatometer
 docker build -t sweatometer .
-docker run sweatometer:latest
+docker run -it -p 8080:80 sweatometer:latest
 ```
 
 ## To-dos

--- a/README.md
+++ b/README.md
@@ -11,10 +11,15 @@ how sweaty it is.
 This service is reliant on the [Data Muse API](http://www.datamuse.com/api), which provides a series 
 of word services.
 
+A Docker image is in the [Github package repository](https://github.com/users/RichTeaMan/packages/container/package/sweatometer):
+
+```bash
+sudo docker run -d -p 8080:80 ghcr.io/richteaman/sweatometer
+```
 
 ## Technology
 
-This project uses .NET Core and React.
+This project uses .NET Core and React. A Github action pipeline runs builds and publishes Docker images.
 
 
 ## Services
@@ -28,12 +33,14 @@ Other services will include:
 ## Running
 
 ### Locally
+
 ```bash
 cd Sweatometer
 dotnet run
 ```
 
 ### Via Docker
+
 ```bash
 cd Sweatometer
 docker build -t sweatometer .


### PR DESCRIPTION
This adds a github action that builds and then pushes a docker image to github packages. You'll need to add a key to make the push work which I'll talk you through.

You'll need to do a find and replace for richteaman -> jcassem.

Once an image is pushed the tag 'latest' is updated for TEP purposes.